### PR TITLE
Fix for "invalid_request_error" 

### DIFF
--- a/background.js
+++ b/background.js
@@ -18,6 +18,7 @@ async function sendToClaudeAndExecute(apiKey, prompt, tabId) {
             "content-type": "application/json",
             "x-api-key": apiKey,
             "x-anthropic-version": "2023-06-01",
+            "anthropic-version": "2023-06-01",
             "anthropic-dangerous-direct-browser-access": "true"
         },
         body: JSON.stringify({

--- a/content.js
+++ b/content.js
@@ -21,6 +21,7 @@ function createInputBox() {
   `;
 
     input = document.createElement('input');
+    input.id="webtroller-input";
     input.style.cssText = `
     width: 100%;
     padding: 10px;


### PR DESCRIPTION
Claude throws error below. Fix is to add the header anthropic-version. Left the old `x-anthropic-version` in there for now, but that header is obsolete.

```{
    "type": "error",
    "error": {
        "type": "invalid_request_error",
        "message": "anthropic-version: header is required"
    }
}```